### PR TITLE
feat(release): release as @ubiquity-os

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,9 +14,17 @@ jobs:
   publish-package:
     runs-on: ubuntu-latest
     steps:
+        name: Get GitHub App token
+        uses: tibdex/github-app-token@v1.7.0
+        id: get_installation_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+        
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.get_installation_token.outputs.token }}
           release-type: node
           target-branch: main
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,7 +14,7 @@ jobs:
   publish-package:
     runs-on: ubuntu-latest
     steps:
-        name: Get GitHub App token
+      - name: Get GitHub App token
         uses: tibdex/github-app-token@v1.7.0
         id: get_installation_token
         with:


### PR DESCRIPTION
Resolves #48
QA: https://github.com/wellneverknow/tst/releases/tag/v1.0.0
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Should be able to release as ubiquity-os bot now, you'll need to add `APP_ID` and `APP_PRIVATE_KEY` to the secrets before.

